### PR TITLE
docs: mention Python version and virtual env setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,13 @@ tcc-nic-main/
 ---
 
 ## 🧰 Requisitos
-Instalar dependências:
+- Python 3.11 ou superior
+
+Crie e ative um ambiente virtual antes de instalar as dependências:
+
 ```bash
+python -m venv .venv
+source .venv/bin/activate  # Windows: .venv\\Scripts\\activate
 pip install -r requirements.txt
 ```
 


### PR DESCRIPTION
## Summary
- specify minimum supported Python version
- describe creating and activating a virtual environment before installing dependencies

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68983501164c8323a23485dc98b5fada