### PR TITLE
Use ISO-formatted UTC timestamps for Reddit comments

### DIFF
--- a/reddit_scraper.py
+++ b/reddit_scraper.py
@@ -79,7 +79,7 @@ def fetch_comments_for_pair(
                     "subreddit": str(sub.subreddit),
                     "author": str(c.author),
                     "score": c.score,
-                    "created_utc": datetime.fromtimestamp(c.created_utc),
+                    "created_utc": datetime.utcfromtimestamp(c.created_utc).isoformat(),
                     "body": c.body.replace("\n", " "),
                 }
                 rows.append(enrich_row(row))


### PR DESCRIPTION
## Summary
- record comment creation times using `datetime.utcfromtimestamp(...).isoformat()`

## Testing
- `python -m py_compile reddit_scraper.py`
- `python - <<'PY' ...`

------
https://chatgpt.com/codex/tasks/task_e_689a5377d1708323bc5b1462d420f855