### PR TITLE
Refactor run script with argparse subparsers

### DIFF
--- a/analyze_excel.py
+++ b/analyze_excel.py
@@ -110,16 +110,8 @@ def comparative_analysis(df: pd.DataFrame, metrics: list[str]):
         print(f"  - Impacto vs. outros Abrils: {diff_vs_other_aprils:+.2f}%")
     print("=" * 60 + "\n")
 
-def main():
+def main(metrics=None):
     """Orquestra a análise e geração de gráficos."""
-    parser = argparse.ArgumentParser(description="Analisa indicadores turísticos.")
-    parser.add_argument(
-        "--metrics",
-        nargs="*",
-        help="Lista de indicadores a analisar (padrão: todos)",
-    )
-    args = parser.parse_args()
-
     sns.set(style="whitegrid", palette="viridis")
 
     df = load_data()
@@ -129,11 +121,12 @@ def main():
     non_indicator_fields = {"Year", "Month"}
     available_metrics = [col for col in df.columns if col not in non_indicator_fields]
 
-    if args.metrics:
-        metrics = [m for m in args.metrics if m in available_metrics]
-        missing = set(args.metrics) - set(metrics)
+    if metrics:
+        selected_metrics = [m for m in metrics if m in available_metrics]
+        missing = set(metrics) - set(selected_metrics)
         if missing:
             print(f"Aviso: Indicadores não encontrados: {', '.join(missing)}")
+        metrics = selected_metrics
     else:
         metrics = available_metrics
 
@@ -150,5 +143,13 @@ def main():
 
     print("Análise concluída com sucesso!")
 
+
 if __name__ == "__main__":
-    main()
+    parser = argparse.ArgumentParser(description="Analisa indicadores turísticos.")
+    parser.add_argument(
+        "--metrics",
+        nargs="*",
+        help="Lista de indicadores a analisar (padrão: todos)",
+    )
+    args = parser.parse_args()
+    main(metrics=args.metrics)

--- a/reddit_scraper.py
+++ b/reddit_scraper.py
@@ -151,8 +151,7 @@ def init_reddit_client():
 
 
 # ————— Fluxo principal —————
-def main():
-    args = parse_args()
+def main(post_limit=50, comment_limit=20, output=DATA_PROCESSED / "comments.csv"):
     reddit = init_reddit_client()
 
     # Listas fixas de hobbies e termos depreciativos
@@ -185,17 +184,18 @@ def main():
                 reddit,
                 hobby,
                 insult,
-                posts_limit=args.post_limit,
-                comments_limit=args.comment_limit,
+                posts_limit=post_limit,
+                comments_limit=comment_limit,
             )
-            write_comments_csv(args.output, fieldnames, rows, first_write=first)
+            write_comments_csv(output, fieldnames, rows, first_write=first)
             first = False  # header apenas na primeira escrita
         except Exception as e:
             logging.warning(f"Erro em {hobby}|{insult}: {e}")
         time.sleep(1)  # throttle entre pares
 
-    logging.info(f"✅ Concluído! Veja {args.output}")
+    logging.info(f"✅ Concluído! Veja {output}")
 
 
 if __name__ == "__main__":
-    main()
+    args = parse_args()
+    main(post_limit=args.post_limit, comment_limit=args.comment_limit, output=args.output)

--- a/run.py
+++ b/run.py
@@ -1,69 +1,111 @@
 import argparse
-import sys
+from config import DATA_PROCESSED
+
+
+def run_artists(args):
+    print("▶️ Executando o módulo 'artists_info'...")
+    from artists_info import main as artists_main
+    artists_main()
+
+
+def run_flights(args):
+    print("▶️ Executando o módulo 'flights_parser'...")
+    from flights_parser import process_all_files
+    process_all_files()
+
+
+def run_reddit(args):
+    print("▶️ Executando o módulo 'reddit_scraper'...")
+    from reddit_scraper import main as reddit_main
+    reddit_main(
+        post_limit=args.post_limit,
+        comment_limit=args.comment_limit,
+        output=args.output,
+    )
+
+
+def run_preprocess(args):
+    print("▶️ Executando o módulo 'preprocess_vegas_data'...")
+    from preprocess_vegas_data import main as preprocess_main
+    preprocess_main()
+
+
+def run_excel(args):
+    print("▶️ Executando o módulo 'analyze_excel'...")
+    from analyze_excel import main as excel_main
+    excel_main(metrics=args.metrics)
+
 
 def main():
-    """
-    Ponto de entrada principal para executar os diferentes módulos do projeto.
-    Use:
-        python run.py --module <nome_do_modulo>
+    """Ponto de entrada principal para executar os diferentes módulos do projeto.
+
+    Uso:
+        python run.py <modulo> [opções]
+
     Exemplos:
-        python run.py --module artists
-        python run.py --module flights
-        python run.py --module reddit --post-limit 10
-        python run.py --module preprocess
-        python run.py --module excel
+        python run.py artists
+        python run.py flights
+        python run.py reddit --post-limit 10
+        python run.py preprocess
+        python run.py excel --metrics Visitors
     """
     parser = argparse.ArgumentParser(
         description="Orquestrador de scripts do projeto TCC.",
-        formatter_class=argparse.RawTextHelpFormatter # Melhora a formatação da ajuda
+        formatter_class=argparse.RawTextHelpFormatter,
     )
-    
-    parser.add_argument(
-        "--module",
-        "-m",
-        required=True,
-        choices=["artists", "flights", "reddit", "preprocess", "excel"],
-        help=(
-            "Nome do módulo a ser executado:\n"
-            "  - artists: Coleta dados de artistas (Spotify, Last.fm, etc.).\n"
-            "  - flights: Processa dados brutos de voos para Las Vegas.\n"
-            "  - reddit:  Busca comentários no Reddit (aceita args extras).\n"
-            "  - preprocess:  Padroniza dados.\n"
-            "  - excel:   Analisa dados de turismo de Las Vegas e gera gráficos."
-        )
-    )
-    
-    # Captura o argumento --module antes de passar os restantes
-    args, remaining_args = parser.parse_known_args()
-    
-    if args.module == "artists":
-        print("▶️ Executando o módulo 'artists_info'...")
-        from artists_info import main as artists_main
-        artists_main() # Supõe que a lógica principal de artists_info.py está em uma função main()
-        
-    elif args.module == "flights":
-        print("▶️ Executando o módulo 'flights_parser'...")
-        from flights_parser import process_all_files
-        process_all_files()
-        
-    elif args.module == "reddit":
-        print("▶️ Executando o módulo 'reddit_scraper'...")
-        # Adicionamos os argumentos do reddit_scraper aqui
-        # para que 'python run.py --module reddit --help' funcione
-        from reddit_scraper import main as reddit_main
-        sys.argv = [sys.argv[0]] + remaining_args # Passa os argumentos restantes para o scraper
-        reddit_main()
-        
-    elif args.module == "preprocess":
-        print("▶️ Executando o módulo 'preprocess_vegas_data'...")
-        from preprocess_vegas_data import main as preprocess_main
-        preprocess_main()
+    subparsers = parser.add_subparsers(dest="module", required=True)
 
-    elif args.module == "excel":
-        print("▶️ Executando o módulo 'analyze_excel'...")
-        from analyze_excel import main as excel_main
-        sys.argv = [sys.argv[0]] + remaining_args # Passa os argumentos restantes para o scraper
-        excel_main()
+    artists_parser = subparsers.add_parser(
+        "artists", help="Coleta dados de artistas (Spotify, Last.fm, etc.)"
+    )
+    artists_parser.set_defaults(func=run_artists)
+
+    flights_parser = subparsers.add_parser(
+        "flights", help="Processa dados brutos de voos para Las Vegas."
+    )
+    flights_parser.set_defaults(func=run_flights)
+
+    reddit_parser = subparsers.add_parser(
+        "reddit", help="Busca comentários no Reddit (aceita args extras)."
+    )
+    reddit_parser.add_argument(
+        "--post-limit",
+        type=int,
+        default=50,
+        help="Número máximo de posts para buscar (por par)",
+    )
+    reddit_parser.add_argument(
+        "--comment-limit",
+        type=int,
+        default=20,
+        help="Número máximo de comentários por post",
+    )
+    reddit_parser.add_argument(
+        "--output",
+        default=DATA_PROCESSED / "comments.csv",
+        help="Arquivo CSV de saída",
+    )
+    reddit_parser.set_defaults(func=run_reddit)
+
+    preprocess_parser = subparsers.add_parser(
+        "preprocess", help="Padroniza dados."
+    )
+    preprocess_parser.set_defaults(func=run_preprocess)
+
+    excel_parser = subparsers.add_parser(
+        "excel",
+        help="Analisa dados de turismo de Las Vegas e gera gráficos.",
+    )
+    excel_parser.add_argument(
+        "--metrics",
+        nargs="*",
+        help="Lista de indicadores a analisar (padrão: todos)",
+    )
+    excel_parser.set_defaults(func=run_excel)
+
+    args = parser.parse_args()
+    args.func(args)
+
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
## Summary
- Replace `--module` switch with subcommands for artists, flights, reddit, preprocess and excel
- Wire module-specific options into dedicated subparsers and invoke targets directly
- Update `reddit_scraper` and `analyze_excel` to accept parameters instead of reading `sys.argv`

## Testing
- `python -m py_compile run.py reddit_scraper.py analyze_excel.py`
- `python run.py --help`
- `python run.py reddit --help`
- `python run.py excel --help`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689cbd8d9b948323a068d45ad0bc86f2